### PR TITLE
feat: state of charge by off-peak and schedule UI update

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "express-session": "^1.18.1",
         "http": "^0.0.1-security",
         "https": "^1.0.0",
+        "ioredis": "^5.11.1",
         "jwt-decode": "^4.0.0",
         "moment-timezone": "^0.6.0",
         "node-cron": "^4.2.1",
@@ -219,6 +220,8 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -458,6 +461,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -517,6 +522,8 @@
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -701,6 +708,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -964,6 +973,10 @@
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
@@ -1041,6 +1054,8 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sql-highlight": ["sql-highlight@6.1.0", "", {}, "sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1211,6 +1226,8 @@
     "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "ioredis/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/env/sample.env
+++ b/env/sample.env
@@ -13,3 +13,7 @@ SCHEDULED_JOBS_DISABLED=true
 
 # Enable dry-run mode: schedules fire and are evaluated, but no write calls are sent to the Tesla API
 DRY_RUN=false
+
+# Redis (used to cache Tesla solar history API responses)
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "express-session": "^1.18.1",
     "http": "^0.0.1-security",
     "https": "^1.0.0",
+    "ioredis": "^5.11.1",
     "jwt-decode": "^4.0.0",
     "moment-timezone": "^0.6.0",
     "node-cron": "^4.2.1",

--- a/src/client/components/schedules/Schedules.tsx
+++ b/src/client/components/schedules/Schedules.tsx
@@ -31,6 +31,8 @@ import ListItemText from "@mui/material/ListItemText";
 import Avatar from "@mui/material/Avatar";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { IconButton } from "@mui/material";
+import Switch from "@mui/material/Switch";
+import Tooltip from "@mui/material/Tooltip";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControl from "@mui/material/FormControl";
@@ -46,6 +48,7 @@ import { useNotification } from "../notification/NotificationContext";
 import { v4 as uuidv4 } from "uuid";
 import Badge from "@mui/material/Badge";
 import CheckIcon from "@mui/icons-material/Check";
+import Alert from "@mui/material/Alert";
 
 type SettingsProps = {
   schedule: any;
@@ -96,6 +99,128 @@ function parseTimeAndDaysToCron(time: string, days: string[]) {
 function isFixedTime(cron: string) {
   const [minute, hour] = cron.split(" ");
   return /^\d+$/.test(minute) && /^\d+$/.test(hour);
+}
+
+function humanizeDays(days: string[]): string {
+  if (days.length === 7) return "every day";
+  const weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+  const weekend = ["Sat", "Sun"];
+  if (
+    days.length === 5 &&
+    weekdays.every((d) => days.includes(d)) &&
+    !days.includes("Sat") &&
+    !days.includes("Sun")
+  )
+    return "weekdays";
+  if (days.length === 2 && weekend.every((d) => days.includes(d)))
+    return "weekends";
+  return days.join(", ");
+}
+
+function humanizeCondition(cond: any): string {
+  const { condition, value } = cond;
+  const map: Record<string, string> = {
+    charged: `battery ≥ ${value}%`,
+    discharged: `battery ≤ ${value}%`,
+    backup: "battery at backup reserve",
+    homeUsageAbove: `home usage > ${value} kW`,
+    homeUsageBelow: `home usage ≤ ${value} kW`,
+    solarGenerationAbove: `solar > ${value} kW`,
+    solarGenerationBelow: `solar ≤ ${value} kW`,
+    gridImportAbove: `grid import > ${value} kW`,
+    gridImportBelow: `grid import ≤ ${value} kW`,
+    gridExportAbove: `grid export > ${value} kW`,
+    gridExportBelow: `grid export ≤ ${value} kW`,
+    betweenHours: `between ${value?.from}–${value?.to}`,
+    inSeasonalGridChargeWindow: "within peak charge windows",
+  };
+  return map[condition] ?? condition;
+}
+
+function humanizeAction(action: any): string {
+  const { action: key, value } = action;
+  switch (key) {
+    case "setBackupReserve":
+      return `set backup reserve to ${value}%`;
+    case "setSoftBackupReserve":
+      return `set soft backup reserve to ${value}%`;
+    case "setOperationalMode":
+      return value === "selfPowered"
+        ? "switch to self-powered"
+        : "switch to time-based control";
+    case "setEnergyExports":
+      return value === "solarOnly"
+        ? "export solar only"
+        : "export solar + battery";
+    case "setGridCharging":
+      return `${value} grid charging`;
+    case "setSmartGridCharging": {
+      try {
+        const parsed = JSON.parse(value);
+        return `smart charge to ${parsed.targetSoc}% SOC`;
+      } catch {
+        return "smart grid charging";
+      }
+    }
+    default:
+      return key;
+  }
+}
+
+function summarizeSchedule(schedule: any): string {
+  const actions: any[] = schedule.actions ?? [];
+  const conditions: any[] = schedule.conditions ?? [];
+  const actionStr = actions.map(humanizeAction).join(", ");
+
+  const isSmartCharging = actions.some(
+    (a) => a.action === "setSmartGridCharging",
+  );
+  if (isSmartCharging) {
+    let targetSoc: number | null = null;
+    try {
+      const sa = actions.find((a) => a.action === "setSmartGridCharging");
+      if (sa) targetSoc = JSON.parse(sa.value).targetSoc;
+    } catch {
+      /* ignore */
+    }
+    const soc = targetSoc != null ? `${targetSoc}%` : "?%";
+    if (conditions.some((c) => c.condition === "inSeasonalGridChargeWindow"))
+      return `Smart: charge to ${soc} SOC before peak (TOU)`;
+    const between = conditions.find((c) => c.condition === "betweenHours");
+    if (between) {
+      const { time, days } = parseCronToTimeAndDays(
+        schedule.cron ?? "* * * * *",
+      );
+      const dayStr = days.length ? ` on ${humanizeDays(days)}` : "";
+      return `Smart: charge to ${soc} SOC by ${between.value?.to ?? time}${dayStr}`;
+    }
+    return `Smart: charge to ${soc} SOC`;
+  }
+
+  if (!schedule.cron || schedule.cron === "* * * * *") {
+    const condStr = conditions.map(humanizeCondition).join(" and ");
+    return condStr ? `When ${condStr} → ${actionStr}` : actionStr;
+  }
+
+  const { time, days } = parseCronToTimeAndDays(schedule.cron);
+  const dayStr = days.length ? humanizeDays(days) : "every day";
+  const condStr = conditions.map(humanizeCondition).join(" and ");
+  const whenStr = `Every ${dayStr} at ${time}`;
+  return condStr
+    ? `${whenStr}, if ${condStr} → ${actionStr}`
+    : `${whenStr} → ${actionStr}`;
+}
+
+function timeAgo(date: Date | string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  if (diffSecs < 60) return "just now";
+  const diffMins = Math.floor(diffSecs / 60);
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
 }
 
 type TabOptions = {
@@ -772,14 +897,35 @@ function ActionConfigDialog({
         },
       ],
     },
-    // Add configs for other actions as needed
+    setSmartGridCharging: {
+      label: "Smart Grid Charging",
+      description:
+        "Charges the battery to the target level before each on-peak period. Grid charging supplements solar only when solar alone cannot reach the target in time. Automatically disabled when the peak period begins.",
+      min: 0,
+      max: 100,
+      step: 1,
+      unit: "%",
+    },
   };
   const [tempValue, setTempValue] = useState<string | number | null>(null);
   useEffect(() => {
     if (selectedAction !== null) {
       const config = actionConfig[selectedAction];
-      let initial: string | number | null = actionValues[selectedAction];
-      if (initial == null) {
+      let raw: string | number | null = actionValues[selectedAction];
+      let initial: string | number | null;
+      if (selectedAction === "setSmartGridCharging") {
+        // Value is a JSON string; extract targetSoc for the slider.
+        if (raw != null) {
+          try {
+            initial = (JSON.parse(raw as string) as { targetSoc: number })
+              .targetSoc;
+          } catch {
+            initial = config.max ?? 90;
+          }
+        } else {
+          initial = config.max ?? 90;
+        }
+      } else if (raw == null) {
         if (config.options && config.options.length > 0) {
           initial = null;
         } else if (config.max !== undefined) {
@@ -787,6 +933,8 @@ function ActionConfigDialog({
         } else {
           initial = 0;
         }
+      } else {
+        initial = raw;
       }
       setTempValue(initial);
     } else {
@@ -924,8 +1072,12 @@ function ActionConfigDialog({
           variant="contained"
           color="primary"
           onClick={() => {
+            const serialized =
+              selectedAction === "setSmartGridCharging"
+                ? JSON.stringify({ targetSoc: Number(tempValue) })
+                : tempValue;
             setActionValues((prev) => {
-              const updated = { ...prev, [selectedAction]: tempValue };
+              const updated = { ...prev, [selectedAction]: serialized };
               setSchedule((prevSchedule: any) => ({
                 ...prevSchedule,
                 actions: Object.entries(updated)
@@ -1062,6 +1214,390 @@ function BetweenHours({ schedule, setSchedule }: BetweenHoursProps) {
   );
 }
 
+type SeasonalWindow = { seasonName: string; from: string; to: string };
+
+type TariffInfo = { hasTou: boolean; seasons: string[] } | null;
+
+type SmartSettingsProps = {
+  schedule: any;
+  setSchedule: (row: any) => void;
+  setTabValid: (valid: boolean) => void;
+  actionValues: { [key: string]: string | number | null };
+  setSelectedAction: (action: string | null) => void;
+  tariffInfo: TariffInfo;
+  smartMode: "tou" | "customDays";
+  setSmartMode: (mode: "tou" | "customDays") => void;
+  smartDays: string[];
+  setSmartDays: (days: string[]) => void;
+  smartWindow: { from: string; to: string };
+  setSmartWindow: (w: { from: string; to: string }) => void;
+  smartSeasonalWindows: SeasonalWindow[];
+  setSmartSeasonalWindows: (windows: SeasonalWindow[]) => void;
+};
+
+function SmartSettings({
+  schedule,
+  setSchedule,
+  setTabValid,
+  actionValues,
+  setSelectedAction,
+  tariffInfo,
+  smartMode,
+  setSmartMode,
+  smartDays,
+  setSmartDays,
+  smartWindow,
+  setSmartWindow,
+  smartSeasonalWindows,
+  setSmartSeasonalWindows,
+}: SmartSettingsProps) {
+  const theme = useTheme();
+
+  const updateScheduleForCurrentMode = useCallback(
+    (
+      mode: "tou" | "customDays",
+      days: string[],
+      window: { from: string; to: string },
+      seasonalWindows: SeasonalWindow[],
+    ) => {
+      if (mode === "tou") {
+        setSchedule((prev: any) => ({
+          ...prev,
+          cron: "* * * * *",
+          conditions:
+            seasonalWindows.length > 0
+              ? [
+                  {
+                    condition: "inSeasonalGridChargeWindow",
+                    value: seasonalWindows,
+                  },
+                ]
+              : [],
+        }));
+      } else {
+        const dowMap = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+        const dow =
+          days.length === 0
+            ? "*"
+            : days.map((d) => String(dowMap.indexOf(d))).join(",");
+        const cron = `* * * * ${dow}`;
+        const conditions =
+          window.from && window.to
+            ? [
+                {
+                  condition: "betweenHours",
+                  value: { from: window.from, to: window.to },
+                },
+              ]
+            : [];
+        setSchedule((prev: any) => ({ ...prev, cron, conditions }));
+      }
+    },
+    [setSchedule],
+  );
+
+  useEffect(() => {
+    const hasSmartAction = actionValues.setSmartGridCharging != null;
+    const modeValid =
+      smartMode === "tou"
+        ? tariffInfo?.hasTou === true
+        : smartDays.length > 0 && smartWindow.to !== "";
+    setTabValid(hasSmartAction && modeValid);
+  }, [
+    actionValues.setSmartGridCharging,
+    smartMode,
+    tariffInfo,
+    smartDays,
+    smartWindow,
+    setTabValid,
+  ]);
+
+  const handleModeChange = (newMode: "tou" | "customDays") => {
+    setSmartMode(newMode);
+    updateScheduleForCurrentMode(
+      newMode,
+      smartDays,
+      smartWindow,
+      smartSeasonalWindows,
+    );
+  };
+
+  const handleDaysChange = (_: any, newDays: string[]) => {
+    setSmartDays(newDays);
+    updateScheduleForCurrentMode(
+      "customDays",
+      newDays,
+      smartWindow,
+      smartSeasonalWindows,
+    );
+  };
+
+  const handleWindowChange = (field: "from" | "to", val: string) => {
+    const newWindow = { ...smartWindow, [field]: val };
+    setSmartWindow(newWindow);
+    updateScheduleForCurrentMode(
+      "customDays",
+      smartDays,
+      newWindow,
+      smartSeasonalWindows,
+    );
+  };
+
+  const handleSeasonalWindowChange = (
+    seasonName: string,
+    field: "from" | "to",
+    val: string,
+  ) => {
+    const newWindows = smartSeasonalWindows.map((w) =>
+      w.seasonName === seasonName ? { ...w, [field]: val } : w,
+    );
+    setSmartSeasonalWindows(newWindows);
+    updateScheduleForCurrentMode("tou", smartDays, smartWindow, newWindows);
+  };
+
+  const smartActionValue = actionValues.setSmartGridCharging;
+  let targetSocLabel: string | null = null;
+  if (smartActionValue != null) {
+    try {
+      const parsed = JSON.parse(smartActionValue as string) as {
+        targetSoc: number;
+      };
+      targetSocLabel = `Target: ${parsed.targetSoc}%`;
+    } catch {
+      targetSocLabel = null;
+    }
+  }
+
+  return (
+    <Box>
+      <Typography variant="subtitle1" mt={1}>
+        Mode
+      </Typography>
+      <RadioGroup
+        row
+        value={smartMode}
+        onChange={(e) =>
+          handleModeChange(e.target.value as "tou" | "customDays")
+        }
+        sx={{ mt: 0.5, mb: 1 }}
+      >
+        <FormControlLabel
+          value="tou"
+          control={<Radio size="small" />}
+          label="Follow TOU schedule"
+        />
+        <FormControlLabel
+          value="customDays"
+          control={<Radio size="small" />}
+          label="Custom days"
+        />
+      </RadioGroup>
+
+      {smartMode === "tou" && !tariffInfo?.hasTou && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          No Time-of-Use tariff found for this site. Configure a TOU tariff in
+          the Tesla app to use this mode.
+        </Alert>
+      )}
+
+      {smartMode === "customDays" && (
+        <Box mb={2}>
+          <Box display="flex" alignItems="center" gap={1} mb={1}>
+            <CalendarTodayIcon fontSize="small" />
+            <Typography variant="body2">Days</Typography>
+          </Box>
+          <ToggleButtonGroup
+            value={smartDays}
+            onChange={handleDaysChange}
+            size="small"
+            exclusive={false}
+            sx={{ gap: 1 }}
+          >
+            {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
+              <ToggleButton
+                key={day}
+                value={day}
+                sx={{
+                  borderRadius: "50%",
+                  width: 40,
+                  height: 40,
+                  p: 0,
+                  fontWeight: 500,
+                  "&.Mui-selected": {
+                    backgroundColor: theme.palette.action.selected,
+                    color: theme.palette.primary.main,
+                  },
+                  "&.MuiToggleButtonGroup-firstButton": { borderRadius: "50%" },
+                  "&.MuiToggleButtonGroup-middleButton": {
+                    borderRadius: "50%",
+                  },
+                  "&.MuiToggleButtonGroup-lastButton": { borderRadius: "50%" },
+                }}
+              >
+                {day}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Box>
+      )}
+
+      <Box
+        sx={{
+          bgcolor: alpha(
+            theme.palette.background.paper,
+            theme.palette.mode === "light" ? 0.5 : 0.2,
+          ),
+          borderRadius: 2,
+          p: 2,
+          mb: 2,
+          border: 1,
+          borderColor: "divider",
+        }}
+      >
+        <Box display="flex" alignItems="center" gap={1} mb={1}>
+          <BoltIcon fontSize="small" />
+          <Typography variant="body2">
+            Allowed Grid Charge Hours
+            {smartMode === "customDays" ? " (optional)" : ""}
+          </Typography>
+        </Box>
+
+        {smartMode === "tou" && (tariffInfo?.seasons ?? []).length > 0 ? (
+          <Box>
+            {/* Single grid so header and data columns always share the same widths */}
+            <Box
+              display="grid"
+              gridTemplateColumns="auto max-content max-content"
+              columnGap={1}
+              rowGap={1}
+              alignItems="center"
+            >
+              <Typography variant="caption" color="text.secondary">
+                Season
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Earliest
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Latest
+              </Typography>
+              {smartSeasonalWindows.map((sw) => (
+                <>
+                  <Typography
+                    key={`${sw.seasonName}-label`}
+                    variant="body2"
+                    sx={{ textTransform: "capitalize" }}
+                  >
+                    {sw.seasonName}
+                  </Typography>
+                  <TextField
+                    key={`${sw.seasonName}-from`}
+                    type="time"
+                    size="small"
+                    value={sw.from}
+                    onChange={(e) =>
+                      handleSeasonalWindowChange(
+                        sw.seasonName,
+                        "from",
+                        e.target.value,
+                      )
+                    }
+                  />
+                  <TextField
+                    key={`${sw.seasonName}-to`}
+                    type="time"
+                    size="small"
+                    value={sw.to}
+                    onChange={(e) =>
+                      handleSeasonalWindowChange(
+                        sw.seasonName,
+                        "to",
+                        e.target.value,
+                      )
+                    }
+                  />
+                </>
+              ))}
+            </Box>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              mt={1}
+              display="block"
+            >
+              Leave blank to allow grid charging any time off-peak
+            </Typography>
+          </Box>
+        ) : smartMode === "tou" ? (
+          <Typography variant="body2" color="text.secondary">
+            Season information will appear once a TOU tariff is detected.
+          </Typography>
+        ) : (
+          <Box display="flex" alignItems="center" gap={1}>
+            <TextField
+              type="time"
+              size="small"
+              label="Earliest"
+              value={smartWindow.from}
+              onChange={(e) => handleWindowChange("from", e.target.value)}
+              sx={{ width: 130 }}
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+            <TextField
+              type="time"
+              size="small"
+              label="Latest / Charge by"
+              value={smartWindow.to}
+              onChange={(e) => handleWindowChange("to", e.target.value)}
+              sx={{ width: 160 }}
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+          </Box>
+        )}
+      </Box>
+
+      <Typography variant="subtitle1">Actions</Typography>
+      <List disablePadding>
+        <ListItem
+          component="button"
+          secondaryAction={<ChevronRightIcon />}
+          sx={{ bgcolor: theme.palette.action.hover, borderRadius: 2, mt: 1 }}
+          onClick={() => setSelectedAction("setSmartGridCharging")}
+        >
+          <ListItemAvatar>
+            <Badge
+              color="success"
+              overlap="circular"
+              badgeContent={
+                smartActionValue != null ? (
+                  <CheckIcon sx={{ fontSize: 14 }} />
+                ) : null
+              }
+              anchorOrigin={{ vertical: "top", horizontal: "right" }}
+              sx={{
+                "& .MuiBadge-badge": {
+                  minWidth: 16,
+                  height: 16,
+                  padding: 0,
+                  borderRadius: "50%",
+                },
+              }}
+            >
+              <Avatar>
+                <BoltIcon />
+              </Avatar>
+            </Badge>
+          </ListItemAvatar>
+          <ListItemText
+            primary="Smart Grid Charging"
+            secondary={targetSocLabel}
+          />
+        </ListItem>
+      </List>
+    </Box>
+  );
+}
+
 function SiteSelector({
   schedule,
   setSchedule,
@@ -1147,6 +1683,7 @@ export default function Schedules() {
     powerwall: false,
     flow: false,
     actions: false,
+    smart: false,
   });
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [scheduleToDelete, setScheduleToDelete] = useState<any | null>(null);
@@ -1159,7 +1696,18 @@ export default function Schedules() {
     setOperationalMode: null,
     setEnergyExports: null,
     setGridCharging: null,
+    setSmartGridCharging: null,
   });
+  const [smartMode, setSmartMode] = useState<"tou" | "customDays">("tou");
+  const [smartDays, setSmartDays] = useState<string[]>([]);
+  const [smartWindow, setSmartWindow] = useState<{ from: string; to: string }>({
+    from: "",
+    to: "",
+  });
+  const [smartSeasonalWindows, setSmartSeasonalWindows] = useState<
+    SeasonalWindow[]
+  >([]);
+  const [tariffInfo, setTariffInfo] = useState<TariffInfo>(null);
   const theme = useTheme();
   const [availableSites, setAvailableSites] = useState<
     { id: string; site_name: string; is_online: boolean }[]
@@ -1187,6 +1735,69 @@ export default function Schedules() {
   const columns: GridColDef[] = [
     { field: "id", headerName: "ID", flex: 1, minWidth: 80 },
     {
+      field: "enabled",
+      headerName: "",
+      width: 60,
+      sortable: false,
+      renderCell: (params) => (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            width: "100%",
+          }}
+        >
+          <Switch
+            checked={params.row.enabled ?? true}
+            size="small"
+            onClick={(e) => e.stopPropagation()}
+            onChange={() => handleToggleEnabled(params.row)}
+          />
+        </Box>
+      ),
+    },
+    {
+      field: "summary",
+      headerName: "Schedule",
+      flex: 3,
+      minWidth: 260,
+      sortable: false,
+      renderCell: (params) => {
+        const summary = summarizeSchedule(params.row);
+        return (
+          <Tooltip title={summary} placement="top">
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                height: "100%",
+                width: "100%",
+                overflow: "hidden",
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  width: "100%",
+                  color:
+                    params.row.enabled === false
+                      ? "text.disabled"
+                      : "text.primary",
+                }}
+              >
+                {summary}
+              </Typography>
+            </Box>
+          </Tooltip>
+        );
+      },
+    },
+    {
       field: "site_ids",
       headerName: "Sites",
       flex: 2,
@@ -1195,69 +1806,113 @@ export default function Schedules() {
         (value ?? [])
           .map((id) => availableSites.find((s) => s.id === id)?.site_name ?? id)
           .join(", "),
+      renderCell: (params) => (
+        <Tooltip title={params.value} placement="top">
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+              width: "100%",
+              overflow: "hidden",
+            }}
+          >
+            <Typography
+              variant="body2"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                width: "100%",
+              }}
+            >
+              {params.value}
+            </Typography>
+          </Box>
+        </Tooltip>
+      ),
     },
-    { field: "cron", headerName: "Cron", flex: 1, minWidth: 100 },
     {
-      field: "enabled",
-      headerName: "Enabled",
+      field: "status",
+      headerName: "Status",
       flex: 1,
-      minWidth: 80,
-      type: "boolean",
-    },
-    {
-      field: "conditions",
-      headerName: "Conditions",
-      flex: 1,
-      minWidth: 80,
-    },
-    {
-      field: "actions",
-      headerName: "Actions",
-      flex: 1,
-      minWidth: 80,
-    },
-    {
-      field: "last_success_time",
-      headerName: "Last Success",
-      flex: 2,
-      minWidth: 160,
-      valueFormatter: (isoDateString: any) =>
-        isoDateString
-          ? new Date(isoDateString).toLocaleString(undefined, {
-              timeZoneName: "short",
-            })
-          : "",
-    },
-    {
-      field: "last_error_time",
-      headerName: "Last Error",
-      flex: 2,
-      minWidth: 160,
-      valueFormatter: (isoDateString: any) =>
-        isoDateString
-          ? new Date(isoDateString).toLocaleString(undefined, {
-              timeZoneName: "short",
-            })
-          : "",
+      minWidth: 120,
+      sortable: false,
+      renderCell: (params) => {
+        const successDate = params.row.last_success_time
+          ? new Date(params.row.last_success_time)
+          : null;
+        const errorDate = params.row.last_error_time
+          ? new Date(params.row.last_error_time)
+          : null;
+
+        let dotColor: string;
+        let label: string;
+        let tooltipText: string;
+
+        if (!successDate && !errorDate) {
+          dotColor = "text.disabled";
+          label = "Never run";
+          tooltipText = "This schedule has not run yet";
+        } else if (successDate && (!errorDate || successDate > errorDate)) {
+          dotColor = "success.main";
+          label = timeAgo(successDate);
+          tooltipText = `Last run: ${successDate.toLocaleString(undefined, { timeZoneName: "short" })}`;
+        } else {
+          dotColor = "error.main";
+          label = timeAgo(errorDate!);
+          tooltipText = `${params.row.last_error ?? "Unknown error"}\n${errorDate!.toLocaleString(undefined, { timeZoneName: "short" })}`;
+        }
+
+        return (
+          <Tooltip title={tooltipText} placement="left">
+            <Box display="flex" alignItems="center" height="100%" gap={0.75}>
+              <Box
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  bgcolor: dotColor,
+                  flexShrink: 0,
+                }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                {label}
+              </Typography>
+            </Box>
+          </Tooltip>
+        );
+      },
     },
     {
       field: "edit",
-      headerName: "Edit",
-      flex: 1,
-      minWidth: 100,
+      headerName: "",
+      width: 100,
       sortable: false,
       renderCell: (params) => {
         const getTabForSchedule = (schedule: any) => {
+          if (
+            (schedule?.actions ?? []).some(
+              (a: any) => a.action === "setSmartGridCharging",
+            )
+          )
+            return 3;
           if (schedule?.conditions && Array.isArray(schedule.conditions)) {
             const condKey = schedule.conditions[0]?.condition;
-            if (tabOptions.flow.some((opt) => opt.key === condKey)) return 2; // Flow tab
+            if (tabOptions.flow.some((opt) => opt.key === condKey)) return 2;
             if (tabOptions.powerwall.some((opt) => opt.key === condKey))
-              return 1; // Powerwall tab
+              return 1;
           }
-          return 0; // Time tab
+          return 0;
         };
         return (
-          <>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+            }}
+          >
             <IconButton
               onClick={(event) => {
                 event.stopPropagation();
@@ -1285,7 +1940,7 @@ export default function Schedules() {
             >
               <DeleteIcon />
             </IconButton>
-          </>
+          </Box>
         );
       },
     },
@@ -1349,6 +2004,22 @@ export default function Schedules() {
       });
   };
 
+  const handleToggleEnabled = useCallback(
+    async (scheduleRow: any) => {
+      const updated = { ...scheduleRow, enabled: !scheduleRow.enabled };
+      setRows((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+      try {
+        await axios.post("/api/schedule/upsert", updated);
+      } catch {
+        setRows((prev) =>
+          prev.map((r) => (r.id === scheduleRow.id ? scheduleRow : r)),
+        );
+        showNotification("Failed to update schedule", "error", 5000);
+      }
+    },
+    [showNotification],
+  );
+
   useEffect(() => {
     setTabValid((prev) => ({
       ...prev,
@@ -1366,6 +2037,21 @@ export default function Schedules() {
     }
     if (dialogTab === 0 && schedule && schedule.conditions !== null) {
       setSchedule((prev: any) => ({ ...prev, conditions: null }));
+    }
+    if (dialogTab === 3 && schedule) {
+      // For a new schedule (no smart conditions yet), apply sensible defaults.
+      const hasSmartCond = (schedule.conditions ?? []).some(
+        (c: any) =>
+          c.condition === "inSeasonalGridChargeWindow" ||
+          c.condition === "betweenHours",
+      );
+      if (!hasSmartCond) {
+        setSchedule((prev: any) => ({
+          ...prev,
+          cron: "* * * * *",
+          conditions: [],
+        }));
+      }
     }
   }, [dialogTab, schedule]);
 
@@ -1403,11 +2089,69 @@ export default function Schedules() {
     // eslint-disable-next-line
   }, [dialogTab]);
 
+  // Initialize smart UI state when opening an existing smart schedule.
+  useEffect(() => {
+    if (!dialogOpen || dialogTab !== 3 || !schedule) return;
+    const conditions: any[] = schedule.conditions ?? [];
+    const inSeasonalCond = conditions.find(
+      (c) => c.condition === "inSeasonalGridChargeWindow",
+    );
+    const betweenHoursCond = conditions.find(
+      (c) => c.condition === "betweenHours",
+    );
+    if (inSeasonalCond) {
+      setSmartMode("tou");
+      setSmartSeasonalWindows(
+        Array.isArray(inSeasonalCond.value) ? inSeasonalCond.value : [],
+      );
+    } else if (betweenHoursCond) {
+      setSmartMode("customDays");
+      setSmartWindow(betweenHoursCond.value as { from: string; to: string });
+      const dayPart = (schedule.cron ?? "* * * * *").split(" ")[4] ?? "*";
+      if (dayPart !== "*") {
+        const dowMap = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+        setSmartDays(
+          dayPart
+            .split(",")
+            .map((d: string) => dowMap[Number(d)])
+            .filter(Boolean),
+        );
+      }
+    }
+    // eslint-disable-next-line
+  }, [dialogOpen, dialogTab]);
+
+  // Fetch tariff info when the smart tab is open and a site is selected.
+  useEffect(() => {
+    if (dialogTab !== 3) return;
+    const siteId = schedule?.site_ids?.[0];
+    if (!siteId) {
+      setTariffInfo(null);
+      return;
+    }
+    axios
+      .get(`/api/powerwall/tariff-info`, { params: { siteId } })
+      .then((res) => setTariffInfo(res.data.data ?? null))
+      .catch(() => setTariffInfo(null));
+    // eslint-disable-next-line
+  }, [dialogTab, schedule?.site_ids?.[0]]);
+
+  // Populate seasonal windows from tariff seasons (add new seasons, keep existing values).
+  useEffect(() => {
+    if (!tariffInfo?.seasons) return;
+    setSmartSeasonalWindows((prev) => {
+      const existing = new Map(prev.map((w) => [w.seasonName, w]));
+      return tariffInfo.seasons.map(
+        (name) => existing.get(name) ?? { seasonName: name, from: "", to: "" },
+      );
+    });
+  }, [tariffInfo]);
+
   console.log("schedule", schedule);
   // console.log("actionValues", actionValues);
 
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 3, width: "60%", mx: "auto" }}>
       <Typography variant="h4" gutterBottom>
         Schedules
       </Typography>
@@ -1466,7 +2210,12 @@ export default function Schedules() {
               setOperationalMode: null,
               setEnergyExports: null,
               setGridCharging: null,
+              setSmartGridCharging: null,
             });
+            setSmartMode("tou");
+            setSmartDays([]);
+            setSmartWindow({ from: "", to: "" });
+            setSmartSeasonalWindows([]);
           }}
         >
           <AddIcon sx={{ fontSize: 24 }} />
@@ -1479,7 +2228,6 @@ export default function Schedules() {
           loading={loading}
           getRowId={(row) => row.id}
           columnVisibilityModel={{ id: false }}
-          checkboxSelection
         />
       </Box>
       <Dialog
@@ -1502,6 +2250,7 @@ export default function Schedules() {
             <Tab key="time" label="Time" />
             <Tab key="powerwall" label="Powerwall" />
             <Tab key="flow" label="Flow" />
+            <Tab key="smart" label="Smart" />
           </Tabs>
           {dialogTab === 0 && (
             <Box mt={2}>
@@ -1569,6 +2318,28 @@ export default function Schedules() {
               />
             </Box>
           )}
+          {dialogTab === 3 && (
+            <Box mt={2}>
+              <SmartSettings
+                schedule={schedule}
+                setSchedule={setSchedule}
+                setTabValid={(valid) =>
+                  setTabValid((v) => ({ ...v, smart: valid }))
+                }
+                actionValues={actionValues}
+                setSelectedAction={setSelectedAction}
+                tariffInfo={tariffInfo}
+                smartMode={smartMode}
+                setSmartMode={setSmartMode}
+                smartDays={smartDays}
+                setSmartDays={setSmartDays}
+                smartWindow={smartWindow}
+                setSmartWindow={setSmartWindow}
+                smartSeasonalWindows={smartSeasonalWindows}
+                setSmartSeasonalWindows={setSmartSeasonalWindows}
+              />
+            </Box>
+          )}
         </DialogContent>
         <DialogActions>
           <Button
@@ -1576,15 +2347,15 @@ export default function Schedules() {
             color="primary"
             sx={{ borderRadius: "10" }}
             disabled={
-              !tabValid[
-                dialogTab === 0
-                  ? "time"
-                  : dialogTab === 1
-                    ? "powerwall"
-                    : "flow"
-              ] ||
-              !tabValid.actions ||
-              !schedule?.site_ids?.length
+              (dialogTab === 3
+                ? !tabValid.smart
+                : !tabValid[
+                    dialogTab === 0
+                      ? "time"
+                      : dialogTab === 1
+                        ? "powerwall"
+                        : "flow"
+                  ] || !tabValid.actions) || !schedule?.site_ids?.length
             }
             onClick={handleSaveSchedule}
           >

--- a/src/server/database/models/schedule.ts
+++ b/src/server/database/models/schedule.ts
@@ -1,9 +1,11 @@
 import { EntitySchema } from "typeorm";
 import type { IBasicEntity } from "~/server/types/common";
 
+export type SeasonalWindow = { seasonName: string; from: string; to: string };
+
 export interface IScheduleCondition {
   condition: string;
-  value: number | { from: string; to: string };
+  value: number | { from: string; to: string } | SeasonalWindow[];
 }
 export interface IScheduleAction {
   action: string;

--- a/src/server/routes/powerwall.ts
+++ b/src/server/routes/powerwall.ts
@@ -1,5 +1,10 @@
 import express from "express";
 import { Fleet } from "~/server/util/fleet";
+import {
+  parseTariffContent,
+  hasTouData,
+  getSeasonNames,
+} from "~/server/util/tariff";
 
 export const router = express.Router();
 
@@ -29,6 +34,41 @@ router.get("/sites", async (req, res) => {
     });
   } catch (error: any) {
     logger.error(error, "Error fetching powerwall sites");
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.get("/tariff-info", async (req, res) => {
+  const email = req.session.user;
+  if (!email) {
+    res.status(401).json({ success: false, message: "Unauthorized" });
+    return;
+  }
+  const siteId = req.query.siteId as string | undefined;
+  if (!siteId) {
+    res
+      .status(400)
+      .json({ success: false, message: "siteId query parameter required" });
+    return;
+  }
+  try {
+    const fleet = Fleet.getInstance(email, {
+      throwOnError: false,
+      mailOnError: false,
+    });
+    const products = await fleet.getEnergyProducts();
+    const product = products.find((p) => p.id === siteId);
+    if (!product) {
+      res.status(404).json({ success: false, message: "Site not found" });
+      return;
+    }
+    const siteInfo = await fleet.getSiteInfo(product);
+    const tariff = parseTariffContent(siteInfo?.tariff_content);
+    const hasTou = hasTouData(tariff);
+    const seasons = tariff ? getSeasonNames(tariff) : [];
+    res.json({ success: true, data: { hasTou, seasons } });
+  } catch (error: any) {
+    logger.error(error, "Error fetching tariff info");
     res.status(500).json({ success: false, message: error.message });
   }
 });

--- a/src/server/types/common.ts
+++ b/src/server/types/common.ts
@@ -30,10 +30,70 @@ export interface UserSettings {
   [key: string]: unknown;
 }
 
+export interface Gateway {
+  device_id: string;
+  part_name?: string;
+  is_active: boolean;
+  leader_device_id?: string;
+  // PW3 lead gateway reports total system capacity in Wh; absent/0 on non-lead units.
+  nameplate_energy_watts?: number;
+}
+
+export interface Battery {
+  device_id: string;
+  part_name?: string; // "Powerwall 2" | "Unknown" (expansion) | undefined
+  is_active: boolean;
+  // PW2 batteries report their individual capacity in Wh; always 0 on PW3 expansion packs.
+  nameplate_energy?: number;
+}
+
 export interface SiteComponents {
   disallow_charge_from_grid_with_solar_installed?: boolean;
   customer_preferred_export_rule?: string; // "pv_only" | "battery_ok"
+  gateways?: Gateway[];
+  batteries?: Battery[];
   [key: string]: unknown;
+}
+
+export interface TouPeriod {
+  fromDayOfWeek: number;
+  toDayOfWeek: number;
+  fromHour: number;
+  toHour: number;
+  fromMinute: number;
+  toMinute: number;
+}
+
+export interface TariffSeason {
+  fromDay: number;
+  fromMonth: number;
+  toDay: number;
+  toMonth: number;
+  tou_periods: {
+    // Tesla API returns uppercase keys (ON_PEAK); lowercase kept for compat.
+    on_peak?: TouPeriod[];
+    ON_PEAK?: TouPeriod[];
+    [key: string]: TouPeriod[] | undefined;
+  };
+}
+
+export interface TariffContent {
+  // Tesla API returns seasons directly at the top level of tariff_content.
+  seasons?: Record<string, TariffSeason>;
+  // Some firmware versions nest seasons under utility_rates; support both.
+  utility_rates?: {
+    seasons?: Record<string, TariffSeason>;
+  };
+}
+
+export interface SolarPowerDataPoint {
+  timestamp: string; // ISO 8601
+  solar_power: number; // Watts
+}
+
+export interface SmartChargingActionConfig {
+  targetSoc: number;
+  solarEfficiencyFactor?: number; // defaults to 0.5; not exposed in UI
 }
 
 export interface SiteInfo {

--- a/src/server/util/chargeRate.ts
+++ b/src/server/util/chargeRate.ts
@@ -1,0 +1,52 @@
+import type { SiteComponents } from "~/server/types/common";
+
+const SAFETY_FACTOR = 0.8;
+const PW3_LEAD_WITH_EXPANSION_KW = 8;
+const PW3_MASTER_KW = 5;
+const PW2_BATTERY_KW = 5;
+
+/**
+ * Returns total usable battery capacity in kWh.
+ * PW3: nameplate_energy_watts (Wh) on the lead gateway covers the whole system.
+ * PW2: nameplate_energy (Wh) on each battery pod; summed across active units.
+ * Returns 0 if the API does not expose capacity for this configuration.
+ */
+export function calculateTotalCapacityKwh(components: SiteComponents): number {
+  const gateways = (components.gateways ?? []).filter((g) => g.is_active);
+  const batteries = (components.batteries ?? []).filter((b) => b.is_active);
+
+  const pw3Lead = gateways.find(
+    (g) => g.part_name === "Powerwall 3" && (g.nameplate_energy_watts ?? 0) > 0,
+  );
+  if (pw3Lead) {
+    return pw3Lead.nameplate_energy_watts! / 1000;
+  }
+
+  const pw2TotalWh = batteries
+    .filter((b) => b.part_name === "Powerwall 2")
+    .reduce((sum, b) => sum + (b.nameplate_energy ?? 0), 0);
+  return pw2TotalWh / 1000;
+}
+
+export function calculateChargeRateKw(components: SiteComponents): number {
+  const gateways = (components.gateways ?? []).filter((g) => g.is_active);
+  const batteries = (components.batteries ?? []).filter((b) => b.is_active);
+
+  const pw3Masters = gateways.filter((g) => g.part_name === "Powerwall 3");
+
+  if (pw3Masters.length > 0) {
+    // Expansion packs always connect to the lead master and have part_name "Unknown".
+    const expansionCount = batteries.filter(
+      (b) => b.part_name === "Unknown",
+    ).length;
+    const leadRateKw =
+      expansionCount > 0 ? PW3_LEAD_WITH_EXPANSION_KW : PW3_MASTER_KW;
+    const additionalMastersRateKw = (pw3Masters.length - 1) * PW3_MASTER_KW;
+    return (leadRateKw + additionalMastersRateKw) * SAFETY_FACTOR;
+  }
+
+  const pw2Count = batteries.filter(
+    (b) => b.part_name === "Powerwall 2",
+  ).length;
+  return pw2Count * PW2_BATTERY_KW * SAFETY_FACTOR;
+}

--- a/src/server/util/fleet.ts
+++ b/src/server/util/fleet.ts
@@ -1,4 +1,5 @@
 import { jwtDecode } from "jwt-decode";
+import moment from "moment-timezone";
 import type {
   FleetOptions,
   FleetOptionsInput,
@@ -7,8 +8,14 @@ import type {
   Product,
   RefreshTokenData,
   SiteInfo,
+  SmartChargingActionConfig,
+  SolarPowerDataPoint,
   TokenData,
 } from "~/server/types/common";
+import type {
+  IScheduleCondition,
+  SeasonalWindow,
+} from "~/server/database/models/schedule";
 import { getNewTokenWithRefreshToken } from "~/server/util/auth";
 import { retry } from "~/server/util/retry";
 import { sendEmail } from "./mailing";
@@ -16,6 +23,40 @@ import {
   upsert as upsertToken,
   getByEmail as getRefreshTokenByEmail,
 } from "~/server/util/routes/refreshToken";
+import {
+  calculateChargeRateKw,
+  calculateTotalCapacityKwh,
+} from "~/server/util/chargeRate";
+import {
+  parseTariffContent,
+  hasTouData,
+  isCurrentlyInPeak,
+  findNextPeakStart,
+  getCurrentSeason,
+  isWithinWindow,
+} from "~/server/util/tariff";
+import { redis } from "~/server/util/redis";
+import {
+  estimateSolarKwhFromHistory,
+  type SolarForecastResult,
+} from "~/server/util/solarForecast";
+
+const SITE_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
+const siteInfoCache = new Map<number, { info: SiteInfo; at: number }>();
+
+function buildSolarLabel(
+  forecast: SolarForecastResult | null,
+  linearKwh: number,
+): string {
+  if (forecast) {
+    const scalePart =
+      forecast.scalingFactor !== 1.0
+        ? ` ×${forecast.scalingFactor.toFixed(2)} weather`
+        : "";
+    return `solar forecast ${forecast.estimatedKwh.toFixed(2)}kWh via ${forecast.daysUsed}-day history${scalePart}`;
+  }
+  return `solar forecast ${linearKwh.toFixed(2)}kWh via linear fallback`;
+}
 
 const baseApiUrl =
   process.env.TESLA_API_BASE_URL ||
@@ -167,6 +208,10 @@ export class Fleet {
   }
 
   async getSiteInfo(product: Product): Promise<SiteInfo | null> {
+    const cached = siteInfoCache.get(product.energy_site_id);
+    if (cached && performance.now() - cached.at < SITE_INFO_CACHE_TTL_MS) {
+      return cached.info;
+    }
     const url = new URL(
       `/api/1/energy_sites/${product.energy_site_id}/site_info`,
       baseApiUrl,
@@ -188,6 +233,10 @@ export class Fleet {
         2,
       );
       const siteInfo = response as SiteInfo;
+      siteInfoCache.set(product.energy_site_id, {
+        info: siteInfo,
+        at: performance.now(),
+      });
       return siteInfo;
     } catch (error: any) {
       const errorMsg = `Error getting Site Info for Energy Site ${product.energy_site_id} after retries: ${error.message}`;
@@ -241,6 +290,156 @@ export class Fleet {
       }
       return null;
     }
+  }
+
+  // Fetch one day of 5-min power data from the Tesla calendar_history API.
+  // dateStr is a YYYY-MM-DD string in the site's local timezone.
+  private async fetchDayHistory(
+    product: Product,
+    timezone: string,
+    dateStr: string,
+    options: { method: string; headers: Record<string, string> },
+  ): Promise<SolarPowerDataPoint[]> {
+    // Avoid 00:00:00 — the API returns empty data at midnight.
+    const endDate = moment
+      .tz(`${dateStr} 23:45`, "YYYY-MM-DD HH:mm", timezone)
+      .format("YYYY-MM-DDTHH:mm:ssZ");
+    const url = new URL(
+      `/api/1/energy_sites/${product.energy_site_id}/calendar_history`,
+      baseApiUrl,
+    );
+    url.searchParams.set("kind", "power");
+    url.searchParams.set("end_date", endDate);
+    try {
+      const { response } = await retry<Record<string, any>>(
+        async () => {
+          const res = await fetch(url.toString(), options);
+          if (!res.ok) {
+            throw new Error(
+              `Error fetching solar history for site ${product.energy_site_id}: ${res.status} ${res.statusText}`,
+            );
+          }
+          return (await res.json()) as Record<string, any>;
+        },
+        3,
+        2000,
+        2,
+      );
+      return (response.time_series ?? []) as SolarPowerDataPoint[];
+    } catch (error: any) {
+      logger.warn(
+        `[solar history] fetch for ${dateStr} failed: ${error.message}`,
+      );
+      return [];
+    }
+  }
+
+  async getSolarHistory(
+    product: Product,
+    timezone: string,
+    days = 7,
+  ): Promise<SolarPowerDataPoint[]> {
+    const cacheKey = `solar_history:${product.energy_site_id}`;
+    const nowLocal = moment().tz(timezone);
+
+    // Cache format: { refreshAfter: ISO string, points: SolarPowerDataPoint[] }.
+    // refreshAfter controls logical freshness; the Redis TTL is intentionally
+    // longer so existing points survive past midnight and can be reused
+    // incrementally — only missing days are fetched on each refresh.
+    let cachedPoints: SolarPowerDataPoint[] = [];
+    try {
+      const raw = await redis.get(cacheKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          // Legacy format (raw array) — treat as stale so it re-stores in new format.
+          cachedPoints = parsed as SolarPowerDataPoint[];
+        } else {
+          const cache = parsed as {
+            refreshAfter: string;
+            points: SolarPowerDataPoint[];
+          };
+          if (moment(cache.refreshAfter).isAfter(nowLocal)) {
+            return cache.points; // still fresh
+          }
+          cachedPoints = cache.points;
+        }
+      }
+    } catch {
+      // Redis unavailable — fall through to API fetch.
+    }
+
+    // Determine which of the past `days` completed days are absent from the
+    // cache. On cold start all 7 are missing; in steady state just 1.
+    const neededDates = Array.from({ length: days }, (_, i) =>
+      nowLocal
+        .clone()
+        .subtract(i + 1, "days")
+        .format("YYYY-MM-DD"),
+    );
+    const cachedDateSet = new Set(
+      cachedPoints.map((p) =>
+        moment.tz(p.timestamp, timezone).format("YYYY-MM-DD"),
+      ),
+    );
+    const missingDates = neededDates.filter((d) => !cachedDateSet.has(d));
+
+    const options = await this.getDefaultGetOptions();
+    const newResults = await Promise.all(
+      missingDates.map((date) =>
+        this.fetchDayHistory(product, timezone, date, options),
+      ),
+    );
+    const newPoints = newResults.flat();
+
+    // Merge: keep existing points still within the window, append new ones.
+    const cutoffDate = nowLocal
+      .clone()
+      .subtract(days, "days")
+      .format("YYYY-MM-DD");
+    const keptPoints = cachedPoints.filter(
+      (p) => moment.tz(p.timestamp, timezone).format("YYYY-MM-DD") > cutoffDate,
+    );
+    const allPoints = [...keptPoints, ...newPoints].sort((a, b) =>
+      a.timestamp.localeCompare(b.timestamp),
+    );
+
+    // Log per-day summary for verification against the Tesla app.
+    if (allPoints.length > 0) {
+      const byDay = new Map<string, number>();
+      for (const p of allPoints) {
+        const day = moment.tz(p.timestamp, timezone).format("YYYY-MM-DD");
+        byDay.set(day, (byDay.get(day) ?? 0) + p.solar_power / 1000 / 12); // 5-min intervals → kWh
+      }
+      const summary = [...byDay.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([d, kwh]) => `${d}: ${kwh.toFixed(2)}kWh`)
+        .join(", ");
+      logger.info(
+        `[solar history] ${allPoints.length} points across ${byDay.size} days — ${summary}`,
+      );
+    } else {
+      logger.warn(
+        `Smart charging: solar history unavailable for site "${product.site_name}"; using linear fallback`,
+      );
+    }
+
+    // Persist with a long TTL; refreshAfter drives logical expiry at next midnight.
+    const updatedCache = {
+      refreshAfter: nowLocal.clone().endOf("day").toISOString(),
+      points: allPoints,
+    };
+    try {
+      await redis.setex(
+        cacheKey,
+        (days + 2) * 24 * 3600,
+        JSON.stringify(updatedCache),
+      );
+    } catch {
+      // Redis write failed — non-fatal.
+    }
+
+    return allPoints;
   }
 
   async setBackupReserve(
@@ -477,6 +676,7 @@ export class Fleet {
         2,
       );
       if (response.ok) {
+        siteInfoCache.delete(product.energy_site_id);
         logger.info(
           `Grid charging set to "${setting}" (disallow=${disallow}) successfully for Energy Site ${product.energy_site_id}.`,
         );
@@ -498,6 +698,271 @@ export class Fleet {
       if (this.options.throwOnError) {
         throw new Error(errorMsg);
       }
+    }
+  }
+
+  async setSmartGridCharging(
+    product: Product,
+    value: string,
+    conditions: IScheduleCondition[] = [],
+  ): Promise<void> {
+    let config: SmartChargingActionConfig;
+    try {
+      config = JSON.parse(value) as SmartChargingActionConfig;
+    } catch {
+      logger.error(
+        `Smart charging: invalid config JSON for site "${product.site_name}": ${value}`,
+      );
+      return;
+    }
+    const solarEfficiencyFactor = config.solarEfficiencyFactor ?? 0.5;
+
+    // siteInfo is cached (5-min TTL) so fetching it first is effectively free
+    // after the first tick. timezone is needed for getSolarHistory.
+    const siteInfo = await this.getSiteInfo(product);
+    if (!siteInfo) {
+      logger.warn(
+        `Smart charging: cannot run — site info unavailable for site "${product.site_name}"`,
+      );
+      return;
+    }
+
+    const timezone = siteInfo.installation_time_zone;
+    const [liveStatus, solarHistory] = await Promise.all([
+      this.getLiveStatus(product),
+      this.getSolarHistory(product, timezone),
+    ]);
+
+    if (!liveStatus) {
+      logger.warn(
+        `Smart charging: cannot run — live status unavailable for site "${product.site_name}"`,
+      );
+      return;
+    }
+    const now = moment().tz(timezone);
+    const currentlyAllowed = !(
+      siteInfo.components.disallow_charge_from_grid_with_solar_installed ??
+      false
+    );
+
+    // PW3 reports capacity via nameplate_energy_watts on the lead gateway;
+    // PW2 reports it via nameplate_energy on each battery pod.
+    const totalEnergyKwh = calculateTotalCapacityKwh(siteInfo.components);
+    if (totalEnergyKwh <= 0) {
+      logger.warn(
+        `Smart charging: battery capacity not available for site "${product.site_name}" — skipping tick`,
+      );
+      return;
+    }
+    const energyNeededKwh = Math.max(
+      0,
+      ((config.targetSoc - liveStatus.percentage_charged) / 100) *
+        totalEnergyKwh,
+    );
+
+    const isTouMode = conditions.some(
+      (c) => c.condition === "inSeasonalGridChargeWindow",
+    );
+    const betweenHoursCond = conditions.find(
+      (c) => c.condition === "betweenHours",
+    );
+
+    let desired: "enabled" | "disabled";
+    let reason: string;
+    let solarForecast: SolarForecastResult | null = null;
+
+    if (isTouMode) {
+      const tariff = parseTariffContent(siteInfo.tariff_content);
+      if (!hasTouData(tariff)) {
+        logger.warn(
+          `Smart charging: no TOU data for site "${product.site_name}" — configure a TOU tariff in the Tesla app`,
+        );
+        return;
+      }
+
+      if (isCurrentlyInPeak(tariff!, now)) {
+        desired = "disabled";
+        reason = "currently in on-peak period";
+      } else if (energyNeededKwh <= 0) {
+        desired = "disabled";
+        reason = `target SOC already reached (${liveStatus.percentage_charged.toFixed(1)}%)`;
+      } else {
+        const nextPeakStart = findNextPeakStart(tariff!, now);
+        if (!nextPeakStart) {
+          desired = "disabled";
+          reason = "no upcoming peak found in tariff";
+        } else {
+          const minutesToPeak = nextPeakStart.diff(now, "minutes");
+          const chargeRateKw = calculateChargeRateKw(siteInfo.components);
+          const availableSolarKw = Math.max(
+            0,
+            (liveStatus.solar_power - liveStatus.load_power) / 1000,
+          );
+          const linearSolarKwh =
+            availableSolarKw * (minutesToPeak / 60) * solarEfficiencyFactor;
+          solarForecast = estimateSolarKwhFromHistory(
+            solarHistory,
+            now,
+            nextPeakStart,
+            availableSolarKw,
+            timezone,
+          );
+          const estimatedSolarKwh =
+            solarForecast !== null
+              ? solarForecast.estimatedKwh
+              : linearSolarKwh;
+          const solarLabel = buildSolarLabel(solarForecast, linearSolarKwh);
+
+          if (estimatedSolarKwh >= energyNeededKwh) {
+            desired = "disabled";
+            reason = `solar expected to cover full ${energyNeededKwh.toFixed(2)}kWh needed (${solarLabel} — grid not needed)`;
+          } else {
+            const gridEnergyKwh = energyNeededKwh - estimatedSolarKwh;
+            const gridChargeHours = gridEnergyKwh / chargeRateKw;
+            const latestGridStart = nextPeakStart
+              .clone()
+              .subtract(gridChargeHours, "hours");
+            const nowIsAtOrAfterLatestStart = !now.isBefore(latestGridStart);
+
+            let withinWindow = true;
+            const windowCond = conditions.find(
+              (c) => c.condition === "inSeasonalGridChargeWindow",
+            );
+            if (windowCond) {
+              const windows = windowCond.value as SeasonalWindow[];
+              const currentSeason = getCurrentSeason(tariff!, now);
+              const seasonWindow = windows.find(
+                (w) => w.seasonName === currentSeason?.name,
+              );
+              if (seasonWindow) {
+                withinWindow = isWithinWindow(
+                  seasonWindow.from,
+                  seasonWindow.to,
+                  now,
+                );
+              }
+            }
+
+            if (nowIsAtOrAfterLatestStart && withinWindow) {
+              desired = "enabled";
+              reason = `grid charging needed — ${gridEnergyKwh.toFixed(2)}kWh at ${chargeRateKw}kW (${solarLabel}, peak at ${nextPeakStart.format("HH:mm")})`;
+            } else if (!nowIsAtOrAfterLatestStart) {
+              desired = "disabled";
+              reason = `waiting — grid will contribute ${gridEnergyKwh.toFixed(2)}kWh at ${chargeRateKw}kW starting ${latestGridStart.format("HH:mm")} (${solarLabel}, peak at ${nextPeakStart.format("HH:mm")})`;
+            } else {
+              desired = "disabled";
+              reason = `outside allowed window — grid start due at ${latestGridStart.format("HH:mm")} but window is closed`;
+            }
+          }
+        }
+      }
+    } else if (betweenHoursCond) {
+      // Custom days mode: betweenHours.to is the charge-by deadline.
+      const window = betweenHoursCond.value as { from: string; to: string };
+      const [th, tm] = window.to.split(":").map(Number);
+      let deadline = now
+        .clone()
+        .hours(th)
+        .minutes(tm)
+        .seconds(0)
+        .milliseconds(0);
+      if (!deadline.isAfter(now)) {
+        deadline = deadline.add(1, "day");
+      }
+
+      if (!now.isBefore(deadline)) {
+        desired = "disabled";
+        reason = `past charge-by deadline ${window.to}`;
+      } else if (energyNeededKwh <= 0) {
+        desired = "disabled";
+        reason = `target SOC already reached (${liveStatus.percentage_charged.toFixed(1)}%)`;
+      } else {
+        const minutesToDeadline = deadline.diff(now, "minutes");
+        const chargeRateKw = calculateChargeRateKw(siteInfo.components);
+        const availableSolarKw = Math.max(
+          0,
+          (liveStatus.solar_power - liveStatus.load_power) / 1000,
+        );
+        const linearSolarKwh =
+          availableSolarKw * (minutesToDeadline / 60) * solarEfficiencyFactor;
+        solarForecast = estimateSolarKwhFromHistory(
+          solarHistory,
+          now,
+          deadline,
+          availableSolarKw,
+          timezone,
+        );
+        const estimatedSolarKwh =
+          solarForecast !== null ? solarForecast.estimatedKwh : linearSolarKwh;
+        const solarLabel = buildSolarLabel(solarForecast, linearSolarKwh);
+
+        if (estimatedSolarKwh >= energyNeededKwh) {
+          desired = "disabled";
+          reason = `solar expected to cover full ${energyNeededKwh.toFixed(2)}kWh needed (${solarLabel} — grid not needed)`;
+        } else {
+          const gridEnergyKwh = energyNeededKwh - estimatedSolarKwh;
+          const gridChargeHours = gridEnergyKwh / chargeRateKw;
+          const latestGridStart = deadline
+            .clone()
+            .subtract(gridChargeHours, "hours");
+          const nowIsAtOrAfterLatestStart = !now.isBefore(latestGridStart);
+          const withinWindow = isWithinWindow(window.from, window.to, now);
+
+          if (nowIsAtOrAfterLatestStart && withinWindow) {
+            desired = "enabled";
+            reason = `grid charging needed — ${gridEnergyKwh.toFixed(2)}kWh at ${chargeRateKw}kW (${solarLabel}, deadline ${window.to})`;
+          } else if (!nowIsAtOrAfterLatestStart) {
+            desired = "disabled";
+            reason = `waiting — grid will contribute ${gridEnergyKwh.toFixed(2)}kWh at ${chargeRateKw}kW starting ${latestGridStart.format("HH:mm")} (${solarLabel}, deadline ${window.to})`;
+          } else {
+            desired = "disabled";
+            reason = `outside allowed window — grid start due at ${latestGridStart.format("HH:mm")} but window is closed`;
+          }
+        }
+      }
+    } else {
+      logger.warn(
+        `Smart charging: no recognised condition for site "${product.site_name}" — skipping`,
+      );
+      return;
+    }
+
+    if (process.env.DRY_RUN === "true") {
+      logger.info(
+        {
+          dryRun: true,
+          site: product.site_name,
+          energySiteId: product.energy_site_id,
+          currentlyAllowed,
+          desired,
+          soc: liveStatus.percentage_charged,
+          targetSoc: config.targetSoc,
+          forecastMethod:
+            solarForecast !== null ? "historical" : "linear-fallback",
+          estimatedSolarKwh: solarForecast
+            ? Math.round(solarForecast.estimatedKwh * 100) / 100
+            : null,
+          reason,
+        },
+        `[DRY RUN] Smart charging "${product.site_name}": desired=${desired}, current=${currentlyAllowed ? "enabled" : "disabled"} — ${reason}`,
+      );
+      return;
+    }
+
+    if (desired === "enabled" && !currentlyAllowed) {
+      logger.info(
+        `Smart charging [${product.site_name}]: enabling grid charging — ${reason}`,
+      );
+      await this.setGridCharging(product, "enabled");
+    } else if (desired === "disabled" && currentlyAllowed) {
+      logger.info(
+        `Smart charging [${product.site_name}]: disabling grid charging — ${reason}`,
+      );
+      await this.setGridCharging(product, "disabled");
+    } else {
+      logger.info(
+        `Smart charging [${product.site_name}]: no change (desired=${desired}, current=${currentlyAllowed ? "enabled" : "disabled"}) — ${reason}`,
+      );
     }
   }
 

--- a/src/server/util/redis.ts
+++ b/src/server/util/redis.ts
@@ -1,0 +1,14 @@
+import Redis from "ioredis";
+
+export const redis = new Redis({
+  host: process.env.REDIS_HOST ?? "localhost",
+  port: Number(process.env.REDIS_PORT ?? 6379),
+  lazyConnect: true,
+  maxRetriesPerRequest: 1,
+  connectTimeout: 3000,
+  commandTimeout: 3000,
+});
+
+redis.on("error", () => {
+  // Suppressed — callers wrap commands in try/catch and fall back gracefully.
+});

--- a/src/server/util/scheduler.ts
+++ b/src/server/util/scheduler.ts
@@ -176,10 +176,15 @@ export class Scheduler {
 
           const hasConditions =
             schedule.conditions && schedule.conditions.length > 0;
+          // Smart schedules run on every tick and pass conditions to the action
+          // as context rather than using them to gate execution.
+          const isSmartSchedule = (schedule.actions ?? []).some(
+            (a) => a.action === "setSmartGridCharging",
+          );
           let actionsExecuted = 0;
 
           for (const product of products) {
-            if (hasConditions) {
+            if (hasConditions && !isSmartSchedule) {
               const liveStatus = await Fleet.getInstance(
                 schedule.email,
               ).getLiveStatus(product);
@@ -231,7 +236,11 @@ export class Scheduler {
               /* eslint-disable no-unexpected-multiline */
               await Fleet.getInstance(schedule.email)
                 .getActionMap()
-                [config.action](product, config.value);
+                [config.action](
+                  product,
+                  config.value,
+                  schedule.conditions ?? [],
+                );
               /* eslint-enable no-unexpected-multiline */
               actionsExecuted++;
             }
@@ -325,7 +334,10 @@ export class Scheduler {
   }
 
   async upsert(schedule: ISchedule) {
-    if (!this.isValidSchedule(schedule)) {
+    if (!this.validEmails.includes(schedule.email)) {
+      logger.warn(
+        `Schedule for email ${schedule.email} has no corresponding refresh token.`,
+      );
       return;
     }
     const existingTask = this.enabledScheduledTasks.get(schedule.id || "");
@@ -346,7 +358,7 @@ export class Scheduler {
       actions: schedule.actions,
     });
     schedule.id = result?.data?.id ?? schedule.id;
-    if (this.schedulingEnabled) {
+    if (this.schedulingEnabled && this.isValidSchedule(schedule)) {
       await this.initializeOneSchedule(schedule);
     }
     return result;

--- a/src/server/util/solarForecast.ts
+++ b/src/server/util/solarForecast.ts
@@ -1,0 +1,108 @@
+import moment from "moment-timezone";
+import type { Moment } from "moment-timezone";
+import type { SolarPowerDataPoint } from "~/server/types/common";
+
+export interface SolarForecastResult {
+  estimatedKwh: number;
+  scalingFactor: number; // 1.0 when weather scaling was not applied
+  daysUsed: number;
+}
+
+const MIN_SOLAR_FOR_SCALING_KW = 0.3;
+const SCALING_MIN = 0.1;
+const SCALING_MAX = 2.0;
+const MIN_VALID_DAYS = 3;
+const INTERVAL_HOURS = 5 / 60; // Tesla history is 5-minute intervals
+
+/**
+ * Estimates solar energy (kWh) between now and peakStart using historical
+ * 5-minute power data. Scales the average by today's actual solar output
+ * compared to the historical average at the same time of day.
+ * Returns null when there is insufficient history to produce a reliable estimate.
+ */
+export function estimateSolarKwhFromHistory(
+  dataPoints: SolarPowerDataPoint[],
+  now: Moment,
+  peakStart: Moment,
+  currentSolarKw: number,
+  timezone: string,
+): SolarForecastResult | null {
+  if (dataPoints.length === 0) return null;
+
+  const nowMins = now.hours() * 60 + now.minutes();
+  const peakMins = peakStart.hours() * 60 + peakStart.minutes();
+
+  // Group data points by site-local calendar date.
+  type Reading = { todMins: number; solarKw: number };
+  const byDate = new Map<string, Reading[]>();
+  for (const dp of dataPoints) {
+    const m = moment.tz(dp.timestamp, timezone);
+    const key = m.format("YYYY-MM-DD");
+    const reading: Reading = {
+      todMins: m.hours() * 60 + m.minutes(),
+      solarKw: dp.solar_power / 1000,
+    };
+    const bucket = byDate.get(key);
+    if (bucket) {
+      bucket.push(reading);
+    } else {
+      byDate.set(key, [reading]);
+    }
+  }
+
+  const dailyEnergies: number[] = [];
+  const dailySolarAtNow: number[] = [];
+
+  for (const readings of byDate.values()) {
+    const windowReadings = readings.filter(
+      (r) => r.todMins >= nowMins && r.todMins < peakMins,
+    );
+    // Skip days with no readings in the window or where solar was zero throughout
+    // (e.g. night-time windows, fully overcast days, data outages).
+    if (
+      windowReadings.length === 0 ||
+      windowReadings.every((r) => r.solarKw === 0)
+    )
+      continue;
+
+    const energyKwh = windowReadings.reduce(
+      (sum, r) => sum + r.solarKw * INTERVAL_HOURS,
+      0,
+    );
+    dailyEnergies.push(energyKwh);
+
+    // Find the reading closest to the current time of day for weather scaling.
+    const closest = readings.reduce((best, r) =>
+      Math.abs(r.todMins - nowMins) < Math.abs(best.todMins - nowMins)
+        ? r
+        : best,
+    );
+    dailySolarAtNow.push(closest.solarKw);
+  }
+
+  if (dailyEnergies.length < MIN_VALID_DAYS) return null;
+
+  const avgHistoricalKwh =
+    dailyEnergies.reduce((a, b) => a + b, 0) / dailyEnergies.length;
+  const avgHistoricalAtNow =
+    dailySolarAtNow.reduce((a, b) => a + b, 0) / dailySolarAtNow.length;
+
+  // Only scale when both sides carry meaningful solar signal. Below the
+  // threshold (pre-sunrise, heavy overcast) the raw historical average is used.
+  let scalingFactor = 1.0;
+  if (
+    currentSolarKw >= MIN_SOLAR_FOR_SCALING_KW &&
+    avgHistoricalAtNow >= MIN_SOLAR_FOR_SCALING_KW
+  ) {
+    scalingFactor = Math.min(
+      Math.max(currentSolarKw / avgHistoricalAtNow, SCALING_MIN),
+      SCALING_MAX,
+    );
+  }
+
+  return {
+    estimatedKwh: avgHistoricalKwh * scalingFactor,
+    scalingFactor,
+    daysUsed: dailyEnergies.length,
+  };
+}

--- a/src/server/util/tariff.ts
+++ b/src/server/util/tariff.ts
@@ -1,0 +1,143 @@
+import type { Moment } from "moment-timezone";
+import type {
+  TariffContent,
+  TariffSeason,
+  TouPeriod,
+} from "~/server/types/common";
+
+export function parseTariffContent(raw: unknown): TariffContent | null {
+  if (!raw || typeof raw !== "object") return null;
+  return raw as TariffContent;
+}
+
+/** Tesla API places seasons directly on tariff_content; older firmware nests them under utility_rates. */
+function getSeasons(
+  t: TariffContent,
+): Record<string, TariffSeason> | undefined {
+  return t.utility_rates?.seasons ?? t.seasons;
+}
+
+/** Tesla API uses uppercase ON_PEAK; normalise to whichever key is present. */
+function getOnPeakPeriods(season: TariffSeason): TouPeriod[] {
+  return season.tou_periods?.on_peak ?? season.tou_periods?.ON_PEAK ?? [];
+}
+
+export function hasTouData(t: TariffContent | null): boolean {
+  if (!t) return false;
+  const seasons = getSeasons(t);
+  if (!seasons) return false;
+  return Object.values(seasons).some((s) => getOnPeakPeriods(s).length > 0);
+}
+
+export function getSeasonNames(t: TariffContent): string[] {
+  return Object.keys(getSeasons(t) ?? {});
+}
+
+function isDateInSeason(season: TariffSeason, now: Moment): boolean {
+  const month = now.month() + 1; // 1-12
+  const day = now.date();
+  const nowMD = month * 100 + day;
+  const fromMD = season.fromMonth * 100 + season.fromDay;
+  const toMD = season.toMonth * 100 + season.toDay;
+  if (fromMD <= toMD) {
+    return nowMD >= fromMD && nowMD <= toMD;
+  }
+  // Season crosses year boundary (e.g. Nov–Mar).
+  return nowMD >= fromMD || nowMD <= toMD;
+}
+
+export function getCurrentSeason(
+  t: TariffContent,
+  now: Moment,
+): { name: string; season: TariffSeason } | null {
+  const seasons = getSeasons(t);
+  if (!seasons) return null;
+  for (const [name, season] of Object.entries(seasons)) {
+    if (isDateInSeason(season, now)) {
+      return { name, season };
+    }
+  }
+  return null;
+}
+
+function isMomentInPeriod(period: TouPeriod, now: Moment): boolean {
+  const dow = now.day(); // 0=Sun … 6=Sat
+  if (dow < period.fromDayOfWeek || dow > period.toDayOfWeek) return false;
+  const nowMins = now.hours() * 60 + now.minutes();
+  const fromMins = period.fromHour * 60 + period.fromMinute;
+  const toMins = period.toHour * 60 + period.toMinute;
+  if (fromMins <= toMins) {
+    return nowMins >= fromMins && nowMins < toMins;
+  }
+  // Period wraps midnight.
+  return nowMins >= fromMins || nowMins < toMins;
+}
+
+export function isCurrentlyInPeak(t: TariffContent, now: Moment): boolean {
+  const current = getCurrentSeason(t, now);
+  if (!current) return false;
+  return getOnPeakPeriods(current.season).some((p) => isMomentInPeriod(p, now));
+}
+
+/**
+ * Returns the nearest future on_peak start moment. If we are currently in a
+ * peak the current peak's start is in the past, so we skip it and return the
+ * next one. Returns null when no TOU data or no upcoming peak found within 7 days.
+ */
+export function findNextPeakStart(
+  t: TariffContent,
+  now: Moment,
+): Moment | null {
+  const current = getCurrentSeason(t, now);
+  if (!current) return null;
+  const periods: TouPeriod[] = getOnPeakPeriods(current.season);
+  if (periods.length === 0) return null;
+
+  let earliest: Moment | null = null;
+
+  for (let dayOffset = 0; dayOffset <= 6; dayOffset++) {
+    // Once we already found a candidate, any start on a later day is further
+    // away — no need to keep searching.
+    if (earliest !== null && dayOffset > 0) break;
+
+    const candidate = now.clone().add(dayOffset, "days");
+    const dow = candidate.day();
+
+    for (const period of periods) {
+      if (dow < period.fromDayOfWeek || dow > period.toDayOfWeek) continue;
+
+      const periodStart = candidate
+        .clone()
+        .startOf("day")
+        .add(period.fromHour, "hours")
+        .add(period.fromMinute, "minutes");
+
+      if (periodStart.isAfter(now)) {
+        if (!earliest || periodStart.isBefore(earliest)) {
+          earliest = periodStart;
+        }
+      }
+    }
+  }
+
+  return earliest;
+}
+
+/**
+ * Returns true if `now` falls within the [from, to) window (HH:mm strings).
+ * Handles windows that wrap midnight (e.g. "22:00" to "06:00").
+ * Empty/missing from or to means the window is always open.
+ */
+export function isWithinWindow(from: string, to: string, now: Moment): boolean {
+  if (!from || !to) return true;
+  const [fh, fm] = from.split(":").map(Number);
+  const [th, tm] = to.split(":").map(Number);
+  const nowMins = now.hours() * 60 + now.minutes();
+  const fromMins = fh * 60 + fm;
+  const toMins = th * 60 + tm;
+  if (fromMins <= toMins) {
+    return nowMins >= fromMins && nowMins < toMins;
+  }
+  // Wraps midnight.
+  return nowMins >= fromMins || nowMins < toMins;
+}

--- a/tests/server/chargeRate.test.ts
+++ b/tests/server/chargeRate.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "bun:test";
+import {
+  calculateChargeRateKw,
+  calculateTotalCapacityKwh,
+} from "~/server/util/chargeRate";
+import type { SiteComponents } from "~/server/types/common";
+
+const SAFETY = 0.8;
+
+function makeComponents(
+  gateways: Array<{ part_name?: string; is_active: boolean }>,
+  batteries: Array<{ part_name?: string; is_active: boolean }>,
+): SiteComponents {
+  return {
+    gateways: gateways.map((g, i) => ({ device_id: `gw-${i}`, ...g })),
+    batteries: batteries.map((b, i) => ({ device_id: `bat-${i}`, ...b })),
+  };
+}
+
+describe("calculateChargeRateKw", () => {
+  describe("PW2 systems", () => {
+    it("returns 0 for no batteries", () => {
+      expect(calculateChargeRateKw(makeComponents([], []))).toBe(0);
+    });
+
+    it("1 PW2 = 5 * 0.8 = 4 kW", () => {
+      const components = makeComponents(
+        [],
+        [{ part_name: "Powerwall 2", is_active: true }],
+      );
+      expect(calculateChargeRateKw(components)).toBe(5 * SAFETY);
+    });
+
+    it("3 PW2 = 15 * 0.8 = 12 kW", () => {
+      const components = makeComponents(
+        [],
+        Array.from({ length: 3 }, () => ({
+          part_name: "Powerwall 2",
+          is_active: true,
+        })),
+      );
+      expect(calculateChargeRateKw(components)).toBe(15 * SAFETY);
+    });
+
+    it("ignores inactive PW2 batteries", () => {
+      const components = makeComponents(
+        [],
+        [
+          { part_name: "Powerwall 2", is_active: true },
+          { part_name: "Powerwall 2", is_active: false },
+        ],
+      );
+      expect(calculateChargeRateKw(components)).toBe(5 * SAFETY);
+    });
+  });
+
+  describe("PW3 systems — single master, no expansions", () => {
+    it("1 PW3 master only = 5 * 0.8 = 4 kW", () => {
+      const components = makeComponents(
+        [{ part_name: "Powerwall 3", is_active: true }],
+        [],
+      );
+      expect(calculateChargeRateKw(components)).toBe(5 * SAFETY);
+    });
+  });
+
+  describe("PW3 systems — single master with expansions", () => {
+    it("1 PW3 master + 1 expansion = 8 * 0.8 = 6.4 kW", () => {
+      const components = makeComponents(
+        [{ part_name: "Powerwall 3", is_active: true }],
+        [{ part_name: "Unknown", is_active: true }],
+      );
+      expect(calculateChargeRateKw(components)).toBeCloseTo(8 * SAFETY, 5);
+    });
+
+    it("1 PW3 master + 3 expansions still = 8 * 0.8 (expansions only affect lead rate)", () => {
+      const components = makeComponents(
+        [{ part_name: "Powerwall 3", is_active: true }],
+        Array.from({ length: 3 }, () => ({
+          part_name: "Unknown",
+          is_active: true,
+        })),
+      );
+      expect(calculateChargeRateKw(components)).toBeCloseTo(8 * SAFETY, 5);
+    });
+  });
+
+  describe("PW3 systems — multiple masters", () => {
+    it("2 PW3 masters, no expansions = (5 + 5) * 0.8 = 8 kW", () => {
+      const components = makeComponents(
+        [
+          { part_name: "Powerwall 3", is_active: true },
+          { part_name: "Powerwall 3", is_active: true },
+        ],
+        [],
+      );
+      expect(calculateChargeRateKw(components)).toBe(10 * SAFETY);
+    });
+
+    it("2 PW3 masters + expansions on lead = (8 + 5) * 0.8 = 10.4 kW", () => {
+      const components = makeComponents(
+        [
+          { part_name: "Powerwall 3", is_active: true },
+          { part_name: "Powerwall 3", is_active: true },
+        ],
+        [{ part_name: "Unknown", is_active: true }],
+      );
+      expect(calculateChargeRateKw(components)).toBeCloseTo(13 * SAFETY, 5);
+    });
+
+    it("ignores inactive PW3 masters", () => {
+      const components = makeComponents(
+        [
+          { part_name: "Powerwall 3", is_active: true },
+          { part_name: "Powerwall 3", is_active: false },
+        ],
+        [],
+      );
+      expect(calculateChargeRateKw(components)).toBe(5 * SAFETY);
+    });
+  });
+
+  describe("PW3 presence overrides PW2", () => {
+    it("PW3 gateway present → PW2 batteries are ignored in rate calc", () => {
+      // Unlikely in practice but guard against mixed configs.
+      const components = makeComponents(
+        [{ part_name: "Powerwall 3", is_active: true }],
+        [{ part_name: "Powerwall 2", is_active: true }],
+      );
+      // PW3 path: 1 master, 0 expansions (PW2 battery doesn't count as expansion) → 5 * 0.8
+      expect(calculateChargeRateKw(components)).toBe(5 * SAFETY);
+    });
+  });
+});
+
+describe("calculateTotalCapacityKwh", () => {
+  describe("PW3 systems", () => {
+    it("reads nameplate_energy_watts from the lead PW3 gateway and converts to kWh", () => {
+      const components: SiteComponents = {
+        gateways: [
+          {
+            device_id: "gw-0",
+            part_name: "Powerwall 3",
+            is_active: true,
+            nameplate_energy_watts: 27000,
+          },
+        ],
+        batteries: [],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(27);
+    });
+
+    it("returns 0 when PW3 gateway has no nameplate_energy_watts", () => {
+      const components: SiteComponents = {
+        gateways: [
+          { device_id: "gw-0", part_name: "Powerwall 3", is_active: true },
+        ],
+        batteries: [],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(0);
+    });
+
+    it("ignores inactive PW3 gateways", () => {
+      const components: SiteComponents = {
+        gateways: [
+          {
+            device_id: "gw-0",
+            part_name: "Powerwall 3",
+            is_active: false,
+            nameplate_energy_watts: 27000,
+          },
+        ],
+        batteries: [],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(0);
+    });
+
+    it("uses the first active PW3 gateway with capacity when multiple exist", () => {
+      const components: SiteComponents = {
+        gateways: [
+          {
+            device_id: "gw-0",
+            part_name: "Powerwall 3",
+            is_active: true,
+            nameplate_energy_watts: 27000,
+          },
+          {
+            device_id: "gw-1",
+            part_name: "Powerwall 3",
+            is_active: true,
+            nameplate_energy_watts: 0,
+          },
+        ],
+        batteries: [],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(27);
+    });
+  });
+
+  describe("PW2 systems", () => {
+    it("sums nameplate_energy across active PW2 batteries", () => {
+      const components: SiteComponents = {
+        gateways: [],
+        batteries: [
+          {
+            device_id: "bat-0",
+            part_name: "Powerwall 2",
+            is_active: true,
+            nameplate_energy: 13500,
+          },
+          {
+            device_id: "bat-1",
+            part_name: "Powerwall 2",
+            is_active: true,
+            nameplate_energy: 13500,
+          },
+        ],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(27);
+    });
+
+    it("ignores inactive PW2 batteries", () => {
+      const components: SiteComponents = {
+        gateways: [],
+        batteries: [
+          {
+            device_id: "bat-0",
+            part_name: "Powerwall 2",
+            is_active: true,
+            nameplate_energy: 13500,
+          },
+          {
+            device_id: "bat-1",
+            part_name: "Powerwall 2",
+            is_active: false,
+            nameplate_energy: 13500,
+          },
+        ],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(13.5);
+    });
+
+    it("returns 0 when no active batteries have nameplate_energy", () => {
+      const components: SiteComponents = {
+        gateways: [],
+        batteries: [
+          { device_id: "bat-0", part_name: "Powerwall 2", is_active: true },
+        ],
+      };
+      expect(calculateTotalCapacityKwh(components)).toBe(0);
+    });
+  });
+
+  describe("empty / no components", () => {
+    it("returns 0 for empty components", () => {
+      expect(calculateTotalCapacityKwh({})).toBe(0);
+    });
+  });
+});

--- a/tests/server/solarForecast.test.ts
+++ b/tests/server/solarForecast.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "bun:test";
+import moment from "moment-timezone";
+import { estimateSolarKwhFromHistory } from "~/server/util/solarForecast";
+import type { SolarPowerDataPoint } from "~/server/types/common";
+
+const TZ = "America/Denver";
+
+// Build a set of 5-min data points for a given date. solarByHour is an array
+// of [hourOfDay, solarWatts] pairs; everything else is 0.
+function makeDay(
+  date: string,
+  solarByHour: Array<[number, number]>,
+): SolarPowerDataPoint[] {
+  const map = new Map(solarByHour);
+  const points: SolarPowerDataPoint[] = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 5) {
+      const ts = moment
+        .tz(
+          `${date} ${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`,
+          TZ,
+        )
+        .toISOString();
+      points.push({ timestamp: ts, solar_power: map.get(h) ?? 0 });
+    }
+  }
+  return points;
+}
+
+// 7 identical days with solarWatts from 08:00 to 16:59 (full-hour resolution).
+function makeSeven(solarWatts: number): SolarPowerDataPoint[] {
+  const days: SolarPowerDataPoint[] = [];
+  for (let d = 1; d <= 7; d++) {
+    const date = `2026-06-${String(d).padStart(2, "0")}`;
+    days.push(
+      ...makeDay(
+        date,
+        Array.from(
+          { length: 9 },
+          (_, i) => [8 + i, solarWatts] as [number, number],
+        ),
+      ),
+    );
+  }
+  return days;
+}
+
+const sunnySeven = () => makeSeven(1000);
+
+describe("estimateSolarKwhFromHistory", () => {
+  describe("basic integration", () => {
+    it("returns null for empty data points", () => {
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      expect(estimateSolarKwhFromHistory([], now, peak, 1.0, TZ)).toBeNull();
+    });
+
+    it("returns null when fewer than 3 valid days", () => {
+      const data = sunnySeven().filter(
+        (p) =>
+          p.timestamp.startsWith("2026-06-01") ||
+          p.timestamp.startsWith("2026-06-02"),
+      );
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      expect(estimateSolarKwhFromHistory(data, now, peak, 1.0, TZ)).toBeNull();
+    });
+
+    it("correctly integrates 4 hours of 1kW solar across 7 identical days (no scaling)", () => {
+      // Window 10:00–14:00 (240 min = 4 h). Each 5-min slot = 1kW × (5/60) h.
+      // 48 slots × (1/12) = 4 kWh per day. currentSolarKw < 0.3 so no scaling.
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(
+        sunnySeven(),
+        now,
+        peak,
+        0.0, // pre-sunrise — no scaling
+        TZ,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.estimatedKwh).toBeCloseTo(4, 1);
+      expect(result!.scalingFactor).toBe(1.0);
+      expect(result!.daysUsed).toBe(7);
+    });
+  });
+
+  describe("weather scaling", () => {
+    it("applies scaling when current solar >= 0.3 kW and historical average >= 0.3 kW", () => {
+      // Historical average at 10:00 = 1 kW. Today = 0.5 kW → factor = 0.5.
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(
+        sunnySeven(),
+        now,
+        peak,
+        0.5, // today is 50% of historical average
+        TZ,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.scalingFactor).toBeCloseTo(0.5, 5);
+      expect(result!.estimatedKwh).toBeCloseTo(4 * 0.5, 1);
+    });
+
+    it("clamps scaling factor at 2.0 when today exceeds 2× history", () => {
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(
+        sunnySeven(),
+        now,
+        peak,
+        5.0, // 5× historical
+        TZ,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.scalingFactor).toBe(2.0);
+    });
+
+    it("clamps scaling factor at 0.1 when today is very low vs high historical average", () => {
+      // Historical average at 10:00 = 10 kW. Today = 0.5 kW → raw ratio = 0.05 → clamped to 0.1.
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(
+        makeSeven(10_000), // 10 kW historical
+        now,
+        peak,
+        0.5, // 0.5 / 10 = 0.05, below SCALING_MIN
+        TZ,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.scalingFactor).toBe(0.1);
+    });
+
+    it("skips scaling when current solar is below 0.3 kW (pre-sunrise)", () => {
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(
+        sunnySeven(),
+        now,
+        peak,
+        0.1, // below threshold
+        TZ,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.scalingFactor).toBe(1.0);
+      expect(result!.estimatedKwh).toBeCloseTo(4, 1);
+    });
+
+    it("skips scaling when historical average at current time is below 0.3 kW", () => {
+      // All 7 days have 0 solar at 06:00 (before sunrise in our test data).
+      const data = sunnySeven();
+      const now = moment.tz("2026-06-08 06:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(data, now, peak, 1.0, TZ);
+      // Historical energy 06:00–14:00 includes hours 8–13 = 6 h × 1 kW = 6 kWh.
+      expect(result).not.toBeNull();
+      expect(result!.scalingFactor).toBe(1.0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null when window falls entirely outside solar hours (all zero)", () => {
+      // Window 22:00–23:00 — no solar in history. Days are rejected, <3 valid.
+      const data = sunnySeven();
+      const now = moment.tz("2026-06-08 22:00", TZ);
+      const peak = moment.tz("2026-06-08 23:00", TZ);
+      expect(estimateSolarKwhFromHistory(data, now, peak, 0, TZ)).toBeNull();
+    });
+
+    it("uses only days that have readings in the window", () => {
+      // 5 days with readings 10:00–14:00, plus 2 days with no readings in that window.
+      const goodDays = sunnySeven().filter((p) => {
+        const d = Number(p.timestamp.substring(8, 10));
+        return d <= 5;
+      });
+      const badDays: SolarPowerDataPoint[] = [];
+      for (let d = 6; d <= 7; d++) {
+        const date = `2026-06-${String(d).padStart(2, "0")}`;
+        // Only night-time solar (no readings in window 10:00–14:00)
+        badDays.push(...makeDay(date, [[0, 10]]));
+      }
+      const now = moment.tz("2026-06-08 10:00", TZ);
+      const peak = moment.tz("2026-06-08 14:00", TZ);
+      const result = estimateSolarKwhFromHistory(
+        [...goodDays, ...badDays],
+        now,
+        peak,
+        0.0,
+        TZ,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.daysUsed).toBe(5);
+    });
+  });
+});

--- a/tests/server/tariff.test.ts
+++ b/tests/server/tariff.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from "bun:test";
+import moment from "moment-timezone";
+import {
+  parseTariffContent,
+  hasTouData,
+  getSeasonNames,
+  getCurrentSeason,
+  isCurrentlyInPeak,
+  findNextPeakStart,
+  isWithinWindow,
+} from "~/server/util/tariff";
+import type { TariffContent } from "~/server/types/common";
+
+const TZ = "America/Denver";
+
+// Helper: build a minimal TariffContent with on-peak Mon-Fri 17:00-21:00.
+function makeSummerTariff(): TariffContent {
+  return {
+    utility_rates: {
+      seasons: {
+        summer: {
+          fromMonth: 5,
+          fromDay: 1,
+          toMonth: 9,
+          toDay: 30,
+          tou_periods: {
+            on_peak: [
+              {
+                fromDayOfWeek: 1, // Mon
+                toDayOfWeek: 5, // Fri
+                fromHour: 17,
+                fromMinute: 0,
+                toHour: 21,
+                toMinute: 0,
+              },
+            ],
+          },
+        },
+        winter: {
+          fromMonth: 10,
+          fromDay: 1,
+          toMonth: 4,
+          toDay: 30,
+          tou_periods: {
+            on_peak: [
+              {
+                fromDayOfWeek: 1,
+                toDayOfWeek: 5,
+                fromHour: 18,
+                fromMinute: 0,
+                toHour: 20,
+                toMinute: 0,
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("parseTariffContent", () => {
+  it("returns null for null input", () => {
+    expect(parseTariffContent(null)).toBeNull();
+  });
+  it("returns null for non-object input", () => {
+    expect(parseTariffContent("string")).toBeNull();
+  });
+  it("returns the object cast as TariffContent for a valid object", () => {
+    const obj = { utility_rates: {} };
+    expect(parseTariffContent(obj)).toBe(obj);
+  });
+});
+
+describe("hasTouData", () => {
+  it("returns false for null", () => {
+    expect(hasTouData(null)).toBe(false);
+  });
+  it("returns false for tariff with no seasons", () => {
+    expect(hasTouData({})).toBe(false);
+  });
+  it("returns false when on_peak is empty", () => {
+    const t: TariffContent = {
+      utility_rates: {
+        seasons: {
+          summer: {
+            fromMonth: 5,
+            fromDay: 1,
+            toMonth: 9,
+            toDay: 30,
+            tou_periods: { on_peak: [] },
+          },
+        },
+      },
+    };
+    expect(hasTouData(t)).toBe(false);
+  });
+  it("returns true for a tariff with on_peak periods", () => {
+    expect(hasTouData(makeSummerTariff())).toBe(true);
+  });
+});
+
+describe("getSeasonNames", () => {
+  it("returns season names", () => {
+    expect(getSeasonNames(makeSummerTariff())).toEqual(
+      expect.arrayContaining(["summer", "winter"]),
+    );
+  });
+  it("returns empty array when no seasons", () => {
+    expect(getSeasonNames({})).toEqual([]);
+  });
+});
+
+describe("getCurrentSeason", () => {
+  it("returns summer for a date in June", () => {
+    const now = moment.tz("2024-06-15 10:00", TZ);
+    const result = getCurrentSeason(makeSummerTariff(), now);
+    expect(result?.name).toBe("summer");
+  });
+  it("returns winter for a date in January", () => {
+    const now = moment.tz("2024-01-10 10:00", TZ);
+    const result = getCurrentSeason(makeSummerTariff(), now);
+    expect(result?.name).toBe("winter");
+  });
+  it("returns null when date falls in no season", () => {
+    // Our test tariff has winter ending Apr 30 and summer starting May 1, no gap.
+    // Insert a gap: override so winter ends Mar 31.
+    const t = makeSummerTariff();
+    t.utility_rates!.seasons!["winter"].toMonth = 3;
+    t.utility_rates!.seasons!["winter"].toDay = 31;
+    const now = moment.tz("2024-04-15 10:00", TZ);
+    expect(getCurrentSeason(t, now)).toBeNull();
+  });
+});
+
+describe("isCurrentlyInPeak", () => {
+  it("returns true during on-peak hours on a weekday", () => {
+    // Monday 18:00 in summer
+    const now = moment.tz("2024-06-17 18:00", TZ); // June 17, 2024 is a Monday
+    expect(isCurrentlyInPeak(makeSummerTariff(), now)).toBe(true);
+  });
+  it("returns false before on-peak hours", () => {
+    const now = moment.tz("2024-06-17 16:59", TZ);
+    expect(isCurrentlyInPeak(makeSummerTariff(), now)).toBe(false);
+  });
+  it("returns false after on-peak hours", () => {
+    const now = moment.tz("2024-06-17 21:00", TZ);
+    expect(isCurrentlyInPeak(makeSummerTariff(), now)).toBe(false);
+  });
+  it("returns false on weekends", () => {
+    // Saturday June 15, 2024 at 18:00 — inside the time range but not the DOW range
+    const now = moment.tz("2024-06-15 18:00", TZ);
+    expect(isCurrentlyInPeak(makeSummerTariff(), now)).toBe(false);
+  });
+  it("returns false outside the season", () => {
+    const now = moment.tz("2024-01-10 18:00", TZ);
+    // Winter peak is 18:00-20:00; this SHOULD be true.
+    expect(isCurrentlyInPeak(makeSummerTariff(), now)).toBe(true);
+  });
+});
+
+describe("findNextPeakStart", () => {
+  it("finds today's upcoming peak when called before it starts", () => {
+    // Monday 14:00 — peak starts at 17:00 today
+    const now = moment.tz("2024-06-17 14:00", TZ);
+    const next = findNextPeakStart(makeSummerTariff(), now);
+    expect(next).not.toBeNull();
+    expect(next!.format("HH:mm")).toBe("17:00");
+    expect(next!.isSame(now, "day")).toBe(true);
+  });
+
+  it("finds tomorrow's peak when called after today's peak ends", () => {
+    // Monday 22:00 — today's peak is done, next is Tuesday 17:00
+    const now = moment.tz("2024-06-17 22:00", TZ);
+    const next = findNextPeakStart(makeSummerTariff(), now);
+    expect(next).not.toBeNull();
+    expect(next!.format("YYYY-MM-DD HH:mm")).toBe("2024-06-18 17:00");
+  });
+
+  it("skips weekend when called on Friday after peak", () => {
+    // Friday 22:00 — next peak is Monday
+    const now = moment.tz("2024-06-21 22:00", TZ); // Friday
+    const next = findNextPeakStart(makeSummerTariff(), now);
+    expect(next).not.toBeNull();
+    expect(next!.day()).toBe(1); // Monday
+  });
+
+  it("returns null when no TOU data", () => {
+    const t: TariffContent = { utility_rates: { seasons: {} } };
+    const now = moment.tz("2024-06-17 14:00", TZ);
+    expect(findNextPeakStart(t, now)).toBeNull();
+  });
+});
+
+describe("real SRP E27 tariff shape (top-level seasons + ON_PEAK keys)", () => {
+  // Mirrors the actual structure returned by the Tesla Fleet API.
+  const srpTariff: TariffContent = {
+    seasons: {
+      Summer: {
+        fromDay: 1,
+        toDay: 30,
+        fromMonth: 11,
+        toMonth: 4,
+        tou_periods: {
+          ON_PEAK: [
+            {
+              fromDayOfWeek: 0,
+              toDayOfWeek: 4,
+              fromHour: 5,
+              fromMinute: 0,
+              toHour: 9,
+              toMinute: 0,
+            },
+            {
+              fromDayOfWeek: 0,
+              toDayOfWeek: 4,
+              fromHour: 17,
+              fromMinute: 0,
+              toHour: 21,
+              toMinute: 0,
+            },
+          ],
+        },
+      },
+      Winter: {
+        fromDay: 1,
+        toDay: 31,
+        fromMonth: 5,
+        toMonth: 10,
+        tou_periods: {
+          ON_PEAK: [
+            {
+              fromDayOfWeek: 0,
+              toDayOfWeek: 4,
+              fromHour: 14,
+              fromMinute: 0,
+              toHour: 20,
+              toMinute: 0,
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  it("hasTouData returns true", () => {
+    expect(hasTouData(srpTariff)).toBe(true);
+  });
+
+  it("getSeasonNames returns Summer and Winter", () => {
+    expect(getSeasonNames(srpTariff)).toEqual(
+      expect.arrayContaining(["Summer", "Winter"]),
+    );
+  });
+
+  it("getCurrentSeason returns Winter for June (May–Oct)", () => {
+    // SRP Winter runs May(5)–Oct(10)
+    const now = moment.tz("2024-06-17 10:00", TZ);
+    const result = getCurrentSeason(srpTariff, now);
+    expect(result?.name).toBe("Winter");
+  });
+
+  it("isCurrentlyInPeak returns true during Winter on-peak hours", () => {
+    // Winter ON_PEAK: Mon-Fri 14:00-20:00; June 17 2024 is Monday
+    const now = moment.tz("2024-06-17 16:00", TZ);
+    expect(isCurrentlyInPeak(srpTariff, now)).toBe(true);
+  });
+
+  it("isCurrentlyInPeak returns false before Winter on-peak hours", () => {
+    const now = moment.tz("2024-06-17 13:00", TZ);
+    expect(isCurrentlyInPeak(srpTariff, now)).toBe(false);
+  });
+
+  it("findNextPeakStart finds today's upcoming peak", () => {
+    const now = moment.tz("2024-06-17 10:00", TZ); // Monday before 14:00
+    const next = findNextPeakStart(srpTariff, now);
+    expect(next).not.toBeNull();
+    expect(next!.format("HH:mm")).toBe("14:00");
+  });
+});
+
+describe("isWithinWindow", () => {
+  it("returns true when empty strings are passed", () => {
+    const now = moment.tz("2024-06-17 10:00", TZ);
+    expect(isWithinWindow("", "", now)).toBe(true);
+  });
+
+  it("returns true when now is inside a non-wrapping window", () => {
+    const now = moment.tz("2024-06-17 02:00", TZ);
+    expect(isWithinWindow("22:00", "06:00", now)).toBe(true);
+  });
+
+  it("returns false when now is outside a non-wrapping window", () => {
+    const now = moment.tz("2024-06-17 10:00", TZ);
+    expect(isWithinWindow("22:00", "06:00", now)).toBe(false);
+  });
+
+  it("returns true when now is inside a simple window", () => {
+    const now = moment.tz("2024-06-17 23:00", TZ);
+    expect(isWithinWindow("22:00", "06:00", now)).toBe(true);
+  });
+
+  it("handles exact boundary — fromMins == nowMins is inclusive", () => {
+    const now = moment.tz("2024-06-17 22:00", TZ);
+    expect(isWithinWindow("22:00", "06:00", now)).toBe(true);
+  });
+
+  it("handles exact boundary — toMins == nowMins is exclusive", () => {
+    const now = moment.tz("2024-06-17 06:00", TZ);
+    expect(isWithinWindow("22:00", "06:00", now)).toBe(false);
+  });
+});


### PR DESCRIPTION
**ISSUE:** #2 

**DESCRIPTION:** Dynamic charge level implementation allowing charges by solar to be supplemented by grid charging, while prioritizing solar charging. Additionally reworked UI layout to schedules to make each entry more human understandable.

**TESTING:** Manually tested.

**CONTEXT:** N/A

**CHECKLIST:**

- [x] Code is well-documented (or self-explanatory)
- [x] Tests added/updated as needed
- [ ] Coverage checks pass (do not lower thresholds; keep requirements unchanged)
- [x] Lint/format checks pass (`bun verify`)
- [x] Changes tested locally (include above what you ran)
