### PR TITLE
fix: site id mismatch

### DIFF
--- a/src/client/components/manualSettings/ManualSettings.tsx
+++ b/src/client/components/manualSettings/ManualSettings.tsx
@@ -118,7 +118,7 @@ export default function ManualSettings() {
         .get<{ success: boolean; data: any[] }>("/api/powerwall/status")
         .then((res) => {
           const entry = res.data.data.find(
-            (d: any) => d.product?.id === siteId,
+            (d: any) => String(d.product?.energy_site_id) === siteId,
           );
           if (!entry) {
             showNotification("Site status not found", "warning");


### PR DESCRIPTION
**ISSUE:** N/A

**DESCRIPTION:** Manual settings page had a mismatch comparison for site id and failed to load therefore.

**TESTING:** Manual test locally

**CONTEXT:** N/A

**CHECKLIST:**

- [x] Code is well-documented (or self-explanatory)
- [ ] Tests added/updated as needed
- [ ] Coverage checks pass (do not lower thresholds; keep requirements unchanged)
- [x] Lint/format checks pass (`bun verify`)
- [x] Changes tested locally (include above what you ran)
