### PR TITLE
fix: json logging for prod by default

### DIFF
--- a/src/server/log.ts
+++ b/src/server/log.ts
@@ -2,6 +2,11 @@ import pino from "pino";
 import path from "path";
 
 export default function createLogger(env = Bun.env) {
+  const prettyPrint =
+    env.LOG_PRETTY_PRINT !== undefined
+      ? env.LOG_PRETTY_PRINT === "true"
+      : env.NODE_ENV !== "production";
+
   return pino(
     {
       level: env.LOG_LEVEL ?? "info",
@@ -10,7 +15,7 @@ export default function createLogger(env = Bun.env) {
         level: (label: string): { level: string } => ({ level: label }),
         bindings: (): Record<string, unknown> => ({}),
       },
-      ...((env.LOG_PRETTY_PRINT ?? true) && {
+      ...(prettyPrint && {
         transport: {
           target: path.resolve("node_modules/pino-pretty"),
           options: {


### PR DESCRIPTION
**ISSUE:** N/A

**DESCRIPTION:** JSON logging in prod by default. Dev retains pretty logs. both can always be overridden.

**TESTING:** N/A

**CONTEXT:** N/A

**CHECKLIST:**

- [x] Code is well-documented (or self-explanatory)
- [ ] Tests added/updated as needed
- [ ] Coverage checks pass (do not lower thresholds; keep requirements unchanged)
- [x] Lint/format checks pass (`bun verify`)
- [x] Changes tested locally (include above what you ran)
